### PR TITLE
Add format array type

### DIFF
--- a/hdl/psi_fix_pkg.vhd
+++ b/hdl/psi_fix_pkg.vhd
@@ -31,6 +31,8 @@ package psi_fix_pkg is
 		F	: integer;				-- Fractional bits
 	end record;
 	
+	type PsiFixFmtArray_t is array(natural range<>) of PsiFixFmt_t;
+	
 	type PsiFixRnd_t is (PsiFixRound, PsiFixTrunc);
 	
 	type PsiFixSat_t is (PsiFixWrap, PsiFixSat);
@@ -55,6 +57,9 @@ package psi_fix_pkg is
 	function PsiFix2ClFix(	fmt : PsiFixFmt_t)
 							return FixFormat_t;
 							
+	function PsiFix2ClFix(	fmts : PsiFixFmtArray_t)
+							return FixFormatArray_t;
+							
 	function ClFix2PsiFix(	rnd : FixRound_t)
 							return PsiFixRnd_t;
 								
@@ -62,8 +67,11 @@ package psi_fix_pkg is
 							return PsiFixSat_t;
 								
 	function ClFix2PsiFix(	fmt : FixFormat_t)
-							return PsiFixFmt_t;							
-
+							return PsiFixFmt_t;
+							
+	function ClFix2PsiFix(	fmts : FixFormatArray_t)
+							return PsiFixFmtArray_t;
+							
 	--------------------------------------------------------------------------
 	-- Bittrue available in Python
 	--------------------------------------------------------------------------	
@@ -275,6 +283,16 @@ package body psi_fix_pkg is
 		return ((fmt.S=1), fmt.I, fmt.F);
 	end function;
 	
+	function PsiFix2ClFix(	fmts : PsiFixFmtArray_t)
+							return FixFormatArray_t is
+		variable Fmts_v : FixFormatArray_t(fmts'range);
+	begin
+		for i in fmts'range loop
+			Fmts_v(i) := PsiFix2ClFix(fmts(i));
+		end loop;
+		return Fmts_v;
+	end function;
+	
 	function ClFix2PsiFix(	rnd : FixRound_t)
 							return PsiFixRnd_t is
 	begin
@@ -301,6 +319,16 @@ package body psi_fix_pkg is
 							return PsiFixFmt_t is
 	begin
 		return (choose(fmt.Signed, 1, 0), fmt.Intbits, fmt.FracBits);
+	end function;
+	
+	function ClFix2PsiFix(	fmts : FixFormatArray_t)
+							return PsiFixFmtArray_t is
+		variable Fmts_v : PsiFixFmtArray_t(fmts'range);
+	begin
+		for i in fmts'range loop
+			Fmts_v(i) := ClFix2PsiFix(fmts(i));
+		end loop;
+		return Fmts_v;
 	end function;
 
 	--------------------------------------------------------------------------

--- a/model/psi_fix_pkg.py
+++ b/model/psi_fix_pkg.py
@@ -194,8 +194,7 @@ def PsiFixInRange(a, aFmt : PsiFixFmt,
 ########################################################################################################################
 # Python only (helpers)
 ########################################################################################################################
-# Currently none
 
-
-
-
+def PsiFixWriteFormats(fmts, names, filename):
+    # Note: Do not convert to FixFormat. Rely on PsiFixFmt.__str__ to format the string correctly.
+    cl_fix_write_formats(fmts, names, filename)

--- a/model/psi_fix_pkg.py
+++ b/model/psi_fix_pkg.py
@@ -105,8 +105,6 @@ def PsiFixFromReal(a,
                    rFmt : PsiFixFmt,
                    errSat : bool = True):
     # PsiFix specific implementation because of the errSat parameter that does not exist in cl_fix
-    if np.ndim(a) == 0:
-        a = np.array(a, ndmin=1)
     if errSat:
         if np.max(a) > PsiFixUpperBound(rFmt):
             raise ValueError("PsiFixFromReal: Number {} could not be represented by format {}".format(np.max(a), rFmt))

--- a/model/psi_fix_pkg.py
+++ b/model/psi_fix_pkg.py
@@ -105,17 +105,14 @@ def PsiFixFromReal(a,
                    rFmt : PsiFixFmt,
                    errSat : bool = True):
     # PsiFix specific implementation because of the errSat parameter that does not exist in cl_fix
-    x = np.floor(a*(2**rFmt.F)+0.5)/2**rFmt.F
     if np.ndim(a) == 0:
         a = np.array(a, ndmin=1)
     if errSat:
         if np.max(a) > PsiFixUpperBound(rFmt):
-            raise ValueError("PsiFixFromReal: Number {} could not be represented by format {}".format(max(a), rFmt))
+            raise ValueError("PsiFixFromReal: Number {} could not be represented by format {}".format(np.max(a), rFmt))
         if np.min(a) < PsiFixLowerBound(rFmt):
-            raise ValueError("PsiFixFromReal: Number {} could not be represented by format {}".format(min(a), rFmt))
-    x = np.where(x > PsiFixUpperBound(rFmt), PsiFixUpperBound(rFmt), x)
-    x = np.where(x < PsiFixLowerBound(rFmt), PsiFixLowerBound(rFmt), x)
-    return x
+            raise ValueError("PsiFixFromReal: Number {} could not be represented by format {}".format(np.min(a), rFmt))
+    return cl_fix_from_real(a, PsiFix2ClFix(rFmt), FixSaturate.Sat_s)
 
 def PsiFixFromBitsAsInt(a : int, aFmt : PsiFixFmt):
     return cl_fix_from_bits_as_int(a, PsiFix2ClFix(aFmt))
@@ -172,10 +169,7 @@ def PsiFixShiftLeft(a, aFmt : PsiFixFmt,
         raise ValueError("PsiFixShiftLeft: shift must be <= maxShift")
     if np.any(shift < 0):
         raise ValueError("PsiFixShiftLeft: shift must be > 0")
-    fullFmt = PsiFixFmt(max(aFmt.S, rFmt.S), max(aFmt.I+maxShift, rFmt.I), max(aFmt.F, rFmt.F))
-    fullA = PsiFixResize(a, aFmt, fullFmt)
-    fullOut = fullA*2**shift
-    return PsiFixResize(fullOut, fullFmt, rFmt, rnd, sat)
+    return cl_fix_shift(a, PsiFix2ClFix(aFmt), shift, PsiFix2ClFix(rFmt), PsiFix2ClFix(rnd), PsiFix2ClFix(sat))
 
 def PsiFixShiftRight(a, aFmt : PsiFixFmt,
                      shift : int, maxShift : int,
@@ -186,10 +180,7 @@ def PsiFixShiftRight(a, aFmt : PsiFixFmt,
         raise ValueError("PsiFixShiftRight: shift must be <= maxShift")
     if np.any(shift < 0):
         raise ValueError("PsiFixShiftRight: shift must be > 0")
-    fullFmt = PsiFixFmt(max(aFmt.S, rFmt.S), max(aFmt.I, rFmt.I), max(aFmt.F+maxShift, rFmt.F+1))   #Additional bit for rounding
-    fullA = PsiFixResize(a, aFmt, fullFmt)
-    fullOut = fullA * 2**-shift
-    return PsiFixResize(fullOut, fullFmt, rFmt, rnd, sat)
+    return cl_fix_shift(a, PsiFix2ClFix(aFmt), -shift, PsiFix2ClFix(rFmt), PsiFix2ClFix(rnd), PsiFix2ClFix(sat))
 
 def PsiFixUpperBound(rFmt : PsiFixFmt):
     return cl_fix_max_value(PsiFix2ClFix(rFmt))

--- a/testbench/psi_fix_pkg_tb/psi_fix_pkg_tb.vhd
+++ b/testbench/psi_fix_pkg_tb/psi_fix_pkg_tb.vhd
@@ -64,7 +64,8 @@ begin
 	-- TB Control
 	-------------------------------------------------------------------------
 	p_control : process
-		variable Fmt_v	: PsiFixFmt_t;
+		variable Fmt_v		: PsiFixFmt_t;
+		variable FmtArray_v	: PsiFixFmtArray_t(0 to 1);
 	begin
 		-- *** PsiFixSize ***
 		print("*** PsiFixSize ***");
@@ -694,6 +695,20 @@ begin
 		print("*** PsiFixFmtToString ***");
 		assert "(1, -2, 15)" = PsiFixFmtToString((1, -2, 15)) 
 			report "###ERROR###: Wrong string fmt received" 
+			severity error;
+		
+		-- *** ClFix2PsiFix (PsiFixFmt_t) ***
+		print("*** ClFix2PsiFix (PsiFixFmt_t) ***");
+		Fmt_v := (1,0,15);
+		assert ClFix2PsiFix(PsiFix2ClFix(Fmt_v)) = Fmt_v
+			report "###ERROR###: PsiFixFmt_t -> FixFormat_t -> PsiFixFmt_t failed" 
+			severity error;
+		
+		-- *** ClFix2PsiFix (PsiFixFmtArray_t) ***
+		print("*** ClFix2PsiFix (PsiFixFmtArray_t) ***");
+		FmtArray_v := ((0,-2,3), (1,0,15));
+		assert ClFix2PsiFix(PsiFix2ClFix(FmtArray_v)) = FmtArray_v
+			report "###ERROR###: PsiFixFmtArray_t -> FixFormatArray_t -> PsiFixFmtArray_t failed" 
 			severity error;
 		
 		wait;


### PR DESCRIPTION
Very minor change to define `PsiFixFmtArray_t` type (equivalent to `FixFormatArray_t` in en_cl_fix_pkg.vhd).

## Summary of changes
- **psi_fix_pkg.vhd**
    - Define `PsiFixFmtArray_t` type.
    - Define conversion functions (`PsiFix2ClFix` and `ClFix2PsiFix`) for the new `PsiFixFmtArray_t` type.
- **psi_fix_pkg.py**
    - Define `PsiFixWriteFormats` function, which just directly calls `cl_fix_write_formats` (which writes format arrays to text files).
- **psi_fix_pkg_tb.vhd**
    - Add test cases for `PsiFix2ClFix` and `ClFix2PsiFix` (covering the new `PsiFixFmtArray_t` type).

The testbench (psi_fix_pkg_tb) passes and now prints 2 extra lines, corresponding to the 2 new test cases:

```
# *** ClFix2PsiFix (PsiFixFmt_t) ***
# *** ClFix2PsiFix (PsiFixFmtArray_t) ***
```